### PR TITLE
path_to_FASTA_used_by_DMS SQL error

### DIFF
--- a/R/PNNL_DMS_utils.R
+++ b/R/PNNL_DMS_utils.R
@@ -637,7 +637,6 @@ path_to_FASTA_used_by_DMS <- function(data_package_num, organism_db = NULL)
   } else {
     res <- dbFetch(qry)
   }
-  res <- dbFetch(qry)
   dbClearResult(qry)
   dbDisconnect(con)
   

--- a/R/PNNL_DMS_utils.R
+++ b/R/PNNL_DMS_utils.R
@@ -627,7 +627,9 @@ path_to_FASTA_used_by_DMS <- function(data_package_num, organism_db = NULL)
   qry <- try(dbSendQuery(con, strSQL))
   if (class(qry) == "try-error"){
     organism <- unique(jobRecords$Organism)
-    FASTA_name <- paste0(unique(jobRecords$`Protein Collection List`), ".fasta")
+    FASTA_name <- unique(jobRecords$`Protein Collection List`)
+    FASTA_name <- sub("(^.*),.*$", "\\1", FASTA_name)
+    FASTA_name <- paste0(FASTA_name, ".fasta")
     strSQL2 <- sprintf("Select OG_name,\n OG_organismDBPath\n From T_organisms\n Where OG_name = '%s'", 
                        organism)
     qry <- dbSendQuery(con, strSQL2)


### PR DESCRIPTION
From my testing around, the error is because the table V_Analysis_Job_Detail_Report_2 does not seem to be there.

I tried to find another way to point to the fasta file using the jobRecords "Protein collection list" information as well the T_organisms table in SQL. Whenever the original query fails, it is caught by the if statement and the T_organisms table is used to fetch the appropriate fasta file in "Protein collection list". From there the function proceeds with the result of the query as usual, since the res columns are renamed for compatibility.

Meant to be a temporary fix at best, mainly because "Protein collection list" may contain multiple files separated by a comma. In this fix we take the first element (line 631). Tested with a few data package numbers and seems to work (3821, 3719, 4496). 